### PR TITLE
dump-fs-raw: validate vmcore only, not vmcore-dmesg

### DIFF
--- a/dump-fs-raw/runtest.sh
+++ b/dump-fs-raw/runtest.sh
@@ -38,7 +38,7 @@ dump_fs_raw()
     else
         rm -f "${C_REBOOT}"
 
-        validate_vmcore_exists
+        validate_vmcore_exists vmcore
         ready_to_exit
     fi
 }


### PR DESCRIPTION
For raw dump, vmcore-dmesg is not saved.
from kexec-kdump-howto.txt: "Note that kernel log buffers will not be available if dump target is raw device."

Signed-off-by: xiawu <xiawu@redhat.com>