### PR TITLE
analyse-crash-gcore-cmd: remove gcore related logs only

### DIFF
--- a/analyse-crash-gcore-cmd/runtest.sh
+++ b/analyse-crash-gcore-cmd/runtest.sh
@@ -88,7 +88,7 @@ EOF
     report_file gdb.log
 
 
-    rm -f *.log
+    rm -f gdb.log "${gcore_log}"
     rm -f *.cmd
     ready_to_exit
 }


### PR DESCRIPTION
Old code removed result.log unexpectedly.
Signed-off-by: xiawu <xiawu@redhat.com>