### PR TITLE
Fixed errors

### DIFF
--- a/analyse-crash-gcore-cmd/runtest.sh
+++ b/analyse-crash-gcore-cmd/runtest.sh
@@ -22,6 +22,11 @@
 
 analyse_crash_gcore_cmd()
 {
+    # crash-gcore-command is not supported in s390x/s390
+    if [[ "$(uname -m)" =~ "s390" ]]; then
+        log_warn "- Crash plugin crash-gcore-command is not supported in s390x/s390"
+    fi
+
     crash_prepare
 
     local package_name="crash-gcore-command"

--- a/analyse-crash/runtest.sh
+++ b/analyse-crash/runtest.sh
@@ -85,10 +85,24 @@ EOF
     # must have either the "no_irq_chip" or the "nr_irq_type" symbols to exist.
     # But s390x has none of them:
     if [ "$(uname -m)" != "s390x" ]; then
-        cat <<EOF >>"${K_TMP_DIR}/crash.cmd"
+        cat <<EOF >> "${K_TMP_DIR}/crash.cmd"
 irq
 irq -b
 irq -u
+exit
+EOF
+    else
+        cat <<EOF >> "${K_TMP_DIR}/crash.cmd"
+exit
+EOF
+    fi
+
+    # RHEL releases take different version of crash utility respectively, so
+    # here add cmds specific to versions.
+
+    if [[ "$K_DIST_VER" =~ ^(6|7)$ ]]; then
+        cat <<EOF >> "${K_TMP_DIR}/crash.cmd"
+list -o task_struct.tasks -h init_task
 exit
 EOF
     fi

--- a/lib/kdump.sh
+++ b/lib/kdump.sh
@@ -315,7 +315,8 @@ kdump_restart()
     log_info "- Restart kdump service."
 
     # delete initrd*kdump.img and update timestamp of kdump.conf
-    rm -f /boot/initrd-*kdump.img || rm -f /boot/initramfs-*kdump.img
+    rm -f /boot/initrd-*kdump.img
+    rm -f /boot/initramfs-*kdump.img  # for rhel7
     touch "${K_CONFIG}"
 
     /usr/bin/kdumpctl restart 2>&1 || /sbin/service kdump restart 2>&1 || log_fatal_error "- Failed to start kdump!"


### PR DESCRIPTION
1. Report warn on s390x in analyse-crash-gcore-cmd test.
    s390x doesn't support crash plugin crash-gcore-command
2. Append 'exit' to crash.cmd on s390x and more arch specific
crash cmd.
3. Fix `rm kdump img` cmd.
`rm -f` doesn't return non-zero code if initrd doesn't exist.

Signed-off-by: xiawu <xiawu@redhat.com>