### PR TITLE
Update test logging/exiting

### DIFF
--- a/analyse-crash-gcore-cmd/runtest.sh
+++ b/analyse-crash-gcore-cmd/runtest.sh
@@ -38,9 +38,9 @@ analyse_crash_gcore_cmd()
     install_rpm "${package_name}"
     gcore=$(rpm -ql "${package_name}" | grep gcore.so)
     vmx="/usr/lib/debug/lib/modules/$(uname -r)/vmlinux"
-    [ ! -f "${vmx}" ] && log_fatal_error "- Unable to find vmlinux."
+    [ ! -f "${vmx}" ] && log_error "- Unable to find vmlinux."
     core=$(get_vmcore_path)
-    [ -z "${core}" ] && log_fatal_error "- Unable to find vmcore."
+    [ -z "${core}" ] && log_error "- Unable to find vmcore."
 
     # Get the pid/proc name
     cat<<EOF > pid.cmd
@@ -51,7 +51,7 @@ EOF
     log_info "- # crash ${vmx} ${core} -s -i pid.cmd | tee ${gcore_log}"
     crash "${vmx}" "${core}" -s -i pid.cmd 2>&1 | tee "${gcore_log}"
     [[ ${PIPESTATUS[1]} -eq "0" ]] || {
-        log_fatal_error "- Failed to run crash with pid.cmd. See logs in ${gcore.log}"
+        log_error "- Failed to run crash with pid.cmd. See logs in ${gcore.log}"
     }
 
     log_info "- Getting pid/proc from ${gcore_log}"
@@ -63,7 +63,7 @@ EOF
         log_info "- pid: ${pid}"
         log_info "- proc: ${proc}"
     else
-        log_fatal_error "- ${gcore_log} is empty!"
+        log_error "- ${gcore_log} is empty!"
     fi
 
     # Run gcore
@@ -77,26 +77,24 @@ EOF
     log_info "- # crash ${vmx} ${core} -s -i gcore.cmd | tee -a ${gcore_log}"
     crash ${vmx} ${core} -s -i gcore.cmd 2>&1 | tee -a ${gcore_log}
     [[ ${PIPESTATUS[1]} -eq "0" ]] || {
-        log_fatal_error "- Failed to run crash with pid.cmd. See logs in ${gcore.log}"
+        log_error "- Failed to run crash with pid.cmd. See logs in ${gcore.log}"
     }
     report_file ${gcore_log}
 
     grep -q 'gcore.so: shared object loaded' ${gcore_log} || {
-        log_fatal_error "Failed to load gcore.so"
+        log_error "Failed to load gcore.so"
     }
-    [ -s "core.${pid}.${proc}" ] || log_fatal_error "- File core.${pid}.${proc} doesn't exist."
+    [ -s "core.${pid}.${proc}" ] || log_error "- File core.${pid}.${proc} doesn't exist."
 
     gdb "core.${pid}.${proc}" --quiet -ex q 2>&1 | tee gdb.log
     [[ ${PIPESTATUS[1]} -eq "0" ]] || {
-        log_fatal_error "- Fail to process core.${pid}.${proc} using gdb. See logs in gdb.log"
+        log_error "- Fail to process core.${pid}.${proc} using gdb. See logs in gdb.log"
     }
     report_file gdb.log
 
 
     rm -f gdb.log "${gcore_log}"
     rm -f *.cmd
-    ready_to_exit
 }
 
-log_info "- Start"
-analyse_crash_gcore_cmd
+run_test analyse_crash_gcore_cmd

--- a/analyse-crash-live/runtest.sh
+++ b/analyse-crash-live/runtest.sh
@@ -161,9 +161,6 @@ EOF
     export SKIP_ERROR_PAT="kmem:.*error.*encountered"
     crash_cmd "" "" "" "${K_TMP_DIR}/crash-simple.cmd"
     crash_cmd "" "" "" "${K_TMP_DIR}/crash.cmd" check_crash_output
-
-    ready_to_exit
 }
 
-log_info "- Start"
-analyse_live
+run_test analyse_live

--- a/analyse-crash-trace-cmd/runtest.sh
+++ b/analyse-crash-trace-cmd/runtest.sh
@@ -24,7 +24,7 @@ enable_tracer()
 {
     log_info "- Check & mount debugfs"
     if ! grep -q debugfs /proc/filesystems; then
-        log_fatal_error "- No debugfs available"
+        log_error "- No debugfs available"
     else
         mount -t debugfs nodev ${DEBUG_PATH}
     fi
@@ -40,7 +40,7 @@ enable_tracer()
     log_info "- CURRENT_TRACER: " $(cat "${TRACE_PATH}/current_tracer")
 
     grep "tracer: ${current_tracer}" "${TRACE_PATH}/trace"
-    [ $? -ne 0 ] && log_fatal_error "- Tracer is not enabled. No trace data in pipe!"
+    [ $? -ne 0 ] && log_error "- Tracer is not enabled. No trace data in pipe!"
 }
 
 analyse_crash_trace_cmd()
@@ -98,15 +98,12 @@ EOF
     echo "exit" >> "${K_TMP_DIR}/crash.cmd"
 
     local vmx="/usr/lib/debug/lib/modules/$(uname -r)/vmlinux"
-    [ ! -f "${vmx}" ] && log_fatal_error "- Unable to find vmlinux."
+    [ ! -f "${vmx}" ] && log_error "- Unable to find vmlinux."
 
     local core=$(get_vmcore_path)
-    [ -z "${core}" ] && log_fatal_error "- Unable to find vmcore."
+    [ -z "${core}" ] && log_error "- Unable to find vmcore."
 
     crash_cmd "" "${vmx}" "${core}" "${K_TMP_DIR}/crash.cmd" check_crash_output
-
-    ready_to_exit
 }
 
-log_info "- Start"
-analyse_crash_trace_cmd
+run_test analyse_crash_trace_cmd

--- a/analyse-crash/runtest.sh
+++ b/analyse-crash/runtest.sh
@@ -108,16 +108,13 @@ EOF
     fi
 
     local vmx="/usr/lib/debug/lib/modules/$(uname -r)/vmlinux"
-    [ ! -f "${vmx}" ] && log_fatal_error "- Unable to find vmlinux."
+    [ ! -f "${vmx}" ] && log_error "- Unable to find vmlinux."
 
     local core=$(get_vmcore_path)
-    [ -z "${core}" ] && log_fatal_error "- Unable to find vmcore."
+    [ -z "${core}" ] && log_error "- Unable to find vmcore."
 
     crash_cmd "" "${vmx}" "${core}" "${K_TMP_DIR}/crash-simple.cmd"
     crash_cmd "" "${vmx}" "${core}" "${K_TMP_DIR}/crash.cmd" check_crash_output
-
-    ready_to_exit
 }
 
-log_info "- Start"
-analyse_crash
+run_test analyse_crash

--- a/analyse-eu-readelf/runtest.sh
+++ b/analyse-eu-readelf/runtest.sh
@@ -24,7 +24,7 @@ analyse_eu_readelf()
     crash_prepare
 
     local core=$(get_vmcore_path)
-    [ -z "${core}" ] && log_fatal_error "- Unable to find vmcore."
+    [ -z "${core}" ] && log_error "- Unable to find vmcore."
 
     log_info "- # eu-readelf -a ${core}"
     eu-readelf -a "${core}" 2>&1 | tee "${K_TMP_DIR}/eu-readelf.log"
@@ -32,11 +32,9 @@ analyse_eu_readelf()
 
     report_file "${K_TMP_DIR}/eu-readelf.log"
     if [ "${error_found}" -ne 0 ]; then
-        log_fatal_error "- Fail: eu-readelf returns errors"
+        log_error "- Fail: eu-readelf returns errors"
     fi
-
-    ready_to_exit
 }
 
-log_info "- Start"
-analyse_eu_readelf
+
+run_test analyse_eu_readelf

--- a/analyse-gdb/runtest.sh
+++ b/analyse-gdb/runtest.sh
@@ -39,10 +39,10 @@ quit
 EOF
 
     local vmx="/usr/lib/debug/lib/modules/$(uname -r)/vmlinux"
-    [ ! -f "${vmx}" ] && log_fatal_error "- Unable to find vmlinux."
+    [ ! -f "${vmx}" ] && log_error "- Unable to find vmlinux."
 
     local core=$(get_vmcore_path)
-    [ -z "${core}" ] && log_fatal_error "- Unable to find vmcore."
+    [ -z "${core}" ] && log_error "- Unable to find vmcore."
 
     log_info "- # gdb < ${K_TMP_DIR}/gdb.cmd ${vmx} ${core}"
     gdb < "${K_TMP_DIR}"/gdb.cmd "${vmx}" "${core}" > "${K_TMP_DIR}/gdb.log" 2>&1
@@ -51,9 +51,6 @@ EOF
     report_file "${K_TMP_DIR}/gdb.log"
 
     check_gdb_output "${K_TMP_DIR}/gdb.log"
-
-    ready_to_exit
 }
 
-log_info "- Start"
-analyse_gdb
+run_test analyse_gdb

--- a/analyse-objdump/runtest.sh
+++ b/analyse-objdump/runtest.sh
@@ -24,7 +24,7 @@ analyse_objdump()
     crash_prepare
 
     local core=$(get_vmcore_path)
-    [ -z "${core}" ] && log_fatal_error "- Unable to find vmcore."
+    [ -z "${core}" ] && log_error "- Unable to find vmcore."
 
     log_info "- # objdump -x ${core}"
     objdump -x "${core}" 2>&1 | tee "${K_TMP_DIR}/objdump.log"
@@ -32,11 +32,8 @@ analyse_objdump()
 
     report_file "${K_TMP_DIR}/objdump.log"
     if [[ "${error_found}" -ne 0 ]]; then
-        log_fatal_error "- Fail: objdump returns errors"
+        log_error "- Fail: objdump returns errors"
     fi
-
-    ready_to_exit
 }
 
-log_info "- Start"
-analyse_objdump
+run_test analyse_objdump

--- a/analyse-readelf/runtest.sh
+++ b/analyse-readelf/runtest.sh
@@ -27,7 +27,7 @@ analyse_readelf()
     local warn=0
 
     local core=$(get_vmcore_path)
-    [ -z "${core}" ] && log_fatal_error "- Unable to find vmcore."
+    [ -z "${core}" ] && log_error "- Unable to find vmcore."
 
     log_info "- # readelf -a ${core}"
     readelf -a "${core}" 2>&1 | tee "${K_TMP_DIR}/readelf.log"
@@ -49,11 +49,8 @@ analyse_readelf()
     }
 
     if [[  ${error} -ne 0 || ${warn} -eq 0  ]]; then
-        log_fatal_error "- Fail: readelf returns errors/warnings"
+        log_error "- Fail: readelf returns errors/warnings"
     fi
-
-    ready_to_exit
 }
 
-log_info "- Start"
-analyse_readelf
+run_test analyse_readelf

--- a/clean-up/runtest.sh
+++ b/clean-up/runtest.sh
@@ -39,7 +39,7 @@ clean_up()
     if [ $? -eq 0 ]; then
         log_info "- Deleted vmcore files."
     else
-        log_fatal_error "- Failed to delete vmcore files."
+        log_error "- Failed to delete vmcore files."
     fi
 
     log_info "- Restoring firewall status."
@@ -79,11 +79,9 @@ clean_up()
         if [ $? -eq 0 ]; then
             log_info "- Disabled sshd service."
         else
-            log_fatal_error "- Failed to disable sshd service."
+            log_error "- Failed to disable sshd service."
         fi
     fi
-
-
 
     log_info "- Restoring kdump conf files."
     cp -f "${K_BAK_DIR}"/kdump.conf ${K_CONFIG}
@@ -94,9 +92,7 @@ clean_up()
     rm -rf "${K_INF_DIR}"
 
     log_info "- Done cleaning up"
-    ready_to_exit
 }
 
-log_info "- Start"
-clean_up
+run_test clean_up
 

--- a/crash-altsysrq-c/runtest.sh
+++ b/crash-altsysrq-c/runtest.sh
@@ -28,7 +28,7 @@ crash_altsysrq_c()
         report_system_info
 
         make_module "altsysrq" .
-        insmod ./altsysrq/altsysrq.ko || log_fatal_error "- Fail to insmod altsysrq."
+        insmod ./altsysrq/altsysrq.ko || log_error "- Fail to insmod altsysrq."
 
         touch "${C_REBOOT}"
         sync
@@ -37,14 +37,12 @@ crash_altsysrq_c()
         sync
         echo c > /proc/driver/altsysrq
 
-        log_fatal_error "- Failed to trigger panic!"
+        log_error "- Failed to trigger panic!"
     else
         rm "${C_REBOOT}"
         validate_vmcore_exists
-        ready_to_exit
     fi
 }
 
-log_info "- Start"
-crash_altsysrq_c
+run_test crash_altsysrq_c
 

--- a/crash-hard_lockup/runtest.sh
+++ b/crash-hard_lockup/runtest.sh
@@ -35,10 +35,8 @@ crash_hard_lockup()
     else
         rm -f "${C_REBOOT}"
         validate_vmcore_exists
-        ready_to_exit
     fi
 }
 
-log_info "- Start"
-crash_hard_lockup
+run_test crash_hard_lockup
 

--- a/crash-nmi-switch/runtest.sh
+++ b/crash-nmi-switch/runtest.sh
@@ -31,7 +31,7 @@ crash_nmi_switch()
         install_rpm "OpenIPMI" "ipmitool"
         log_info "- Load IPMI modules"
         systemctl enable ipmi
-        systemctl start ipmi || service ipmi start || log_fatal_error "- Failed to start ipmi service."
+        systemctl start ipmi || service ipmi start || log_error "- Failed to start ipmi service."
 
         echo 1 > /proc/sys/kernel/panic_on_unrecovered_nmi
         touch "${C_REBOOT}"
@@ -41,14 +41,12 @@ crash_nmi_switch()
 
         # Wait for a while
         sleep 60
-        log_fatal_error "- Failed to trigger IPMI crash after waiting for 60s."
+        log_error "- Failed to trigger IPMI crash after waiting for 60s."
     else
         rm -f "${C_REBOOT}"
         validate_vmcore_exists
-        ready_to_exit
     fi
 }
 
-log_info "- Start"
-crash_nmi_switch
+run_test crash_nmi_switch
 

--- a/crash-oops-BUG/runtest.sh
+++ b/crash-oops-BUG/runtest.sh
@@ -33,10 +33,8 @@ crash_oops_BUG()
     else
         rm -f "${C_REBOOT}"
         validate_vmcore_exists
-        ready_to_exit
     fi
 }
 
-log_info "- Start"
-crash_oops_BUG
+run_test crash_oops_BUG
 

--- a/crash-oops-panic/runtest.sh
+++ b/crash-oops-panic/runtest.sh
@@ -32,10 +32,8 @@ crash_oops_panic()
     else
         rm -f "${C_REBOOT}"
         validate_vmcore_exists
-        ready_to_exit
     fi
 }
 
-log_info "- Start"
-crash_oops_panic
+run_test crash_oops_panic
 

--- a/crash-oops-warn/runtest.sh
+++ b/crash-oops-warn/runtest.sh
@@ -30,7 +30,7 @@ crash-oops-warn()
         # Set panic_on_warn
         log_info "- # echo 1 > /proc/sys/kernel/panic_on_warn."
         echo 1 > /proc/sys/kernel/panic_on_warn
-        [[ $? -ne 0 ]] && log_fatal_error "- Error to echo 1 > /proc/sys/kernel/panic_on_warn"
+        [[ $? -ne 0 ]] && log_error "- Error to echo 1 > /proc/sys/kernel/panic_on_warn"
 
         # Trigger panic_on_warn
         touch "${C_REBOOT}"
@@ -40,15 +40,13 @@ crash-oops-warn()
 
         # Wait for a while
         sleep 60
-        log_fatal_error "- Failed to trigger panic_on_warn after waiting for 60s."
+        log_error "- Failed to trigger panic_on_warn after waiting for 60s."
 
     else
         rm -f "${C_REBOOT}"
         validate_vmcore_exists
-        ready_to_exit
     fi
 }
 
-log_info "- Start"
-crash-oops-warn
+run_test crash-oops-warn
 

--- a/crash-panic_on_oops/runtest.sh
+++ b/crash-panic_on_oops/runtest.sh
@@ -32,10 +32,8 @@ crash_panic_on_oops()
     else
         rm -f "${C_REBOOT}"
         validate_vmcore_exists
-        ready_to_exit
     fi
 }
 
-log_info "- Start"
-crash_panic_on_oops
+run_test crash_panic_on_oops
 

--- a/crash-sysrq-c/runtest.sh
+++ b/crash-sysrq-c/runtest.sh
@@ -31,10 +31,8 @@ crash_sysrq_c()
     else
         rm -f "${C_REBOOT}"
         validate_vmcore_exists
-        ready_to_exit
     fi
 }
 
-log_info "- Start"
-crash_sysrq_c
+run_test crash_sysrq_c
 

--- a/dump-ELF/runtest.sh
+++ b/dump-ELF/runtest.sh
@@ -33,10 +33,8 @@ dump_ELF()
     else
         rm -f "${C_REBOOT}"
         validate_vmcore_exists
-        ready_to_exit
     fi
 }
 
-log_info "- Start"
-dump_ELF
+run_test dump_ELF
 

--- a/dump-compression/runtest.sh
+++ b/dump-compression/runtest.sh
@@ -31,7 +31,7 @@ dump_compression()
         # allowed compression options: -c -l -p
 
         [[ "${TESTARGS}" =~ ^(-c|-l|-p)$ ]] || {
-            log_fatal_error "- Invalid compression option ${TESTARGS}"
+            log_error "- Invalid compression option ${TESTARGS}"
         }
         config_kdump_filter "${TESTARGS} -d 31"
         report_system_info
@@ -40,10 +40,8 @@ dump_compression()
     else
         rm -f "${C_REBOOT}"
         validate_vmcore_exists
-        ready_to_exit
     fi
 }
 
-log_info "- Start"
-dump_compression
+run_test dump_compression
 

--- a/dump-dump_level/runtest.sh
+++ b/dump-dump_level/runtest.sh
@@ -34,10 +34,8 @@ dump_dump_level()
     else
         rm -f "${C_REBOOT}"
         validate_vmcore_exists
-        ready_to_exit
     fi
 }
 
-log_info "- Start"
-dump_dump_level
+run_test dump_dump_level
 

--- a/dump-fail-default-reboot/runtest.sh
+++ b/dump-fail-default-reboot/runtest.sh
@@ -35,9 +35,7 @@ dump_fail_default_reboot()
         rm -f "${C_REBOOT}"
         validate_vmcore_not_exists
     fi
-    ready_to_exit
 }
 
-log_info "- Start"
-dump_fail_default_reboot
+run_test dump_fail_default_reboot
 

--- a/dump-fail-default-rootfs/runtest.sh
+++ b/dump-fail-default-rootfs/runtest.sh
@@ -44,9 +44,6 @@ dump_fail_default_rootfs()
         echo "${K_DEFAULT_PATH}" > "${K_PATH}"
         validate_vmcore_exists "dmesg"
     fi
-    ready_to_exit
-
 }
 
-log_info "- Start"
-dump_fail_default_rootfs
+run_test dump_fail_default_rootfs

--- a/dump-fs-ext/runtest.sh
+++ b/dump-fs-ext/runtest.sh
@@ -28,7 +28,7 @@ OPTION="uuid"
 dump_fs_ext()
 {
     if [ ! -f "${C_REBOOT}" ]; then
-        [[ "${TESTARGS}" == ext* ]] || log_fatal_error "- ${TESTARGS} is not a valid ext type"
+        [[ "${TESTARGS}" == ext* ]] || log_error "- ${TESTARGS} is not a valid ext type"
 
         kdump_prepare
         config_kdump_fs ${TESTARGS}
@@ -39,9 +39,7 @@ dump_fs_ext()
         rm -f "${C_REBOOT}"
 
         validate_vmcore_exists
-        ready_to_exit
     fi
 }
 
-log_info "- Start"
-dump_fs_ext
+run_test dump_fs_ext

--- a/dump-fs-raw/runtest.sh
+++ b/dump-fs-raw/runtest.sh
@@ -39,9 +39,7 @@ dump_fs_raw()
         rm -f "${C_REBOOT}"
 
         validate_vmcore_exists vmcore
-        ready_to_exit
     fi
 }
 
-log_info "- Start"
-dump_fs_raw
+run_test dump_fs_raw

--- a/dump-fs-xfs/runtest.sh
+++ b/dump-fs-xfs/runtest.sh
@@ -37,9 +37,7 @@ dump_fs_xfs()
         rm -f "${C_REBOOT}"
 
         validate_vmcore_exists
-        ready_to_exit
     fi
 }
 
-log_info "- Start"
-dump_fs_xfs
+run_test dump_fs_xfs

--- a/dump-kdump_post/runtest.sh
+++ b/dump-kdump_post/runtest.sh
@@ -36,12 +36,10 @@ dump_kdump_post()
         rm -f "${C_REBOOT}"
         report_file /root/kdump-post.log
         grep "dump result 0" /root/kdump-post.log
-        [ $? != 0 ] && log_fatal_error "- Not found \"dump result 0\" in kdump-post.log"
+        [ $? != 0 ] && log_error "- Not found \"dump result 0\" in kdump-post.log"
         validate_vmcore_exists
-        ready_to_exit
     fi
 }
 
-log_info "- Start"
-dump_kdump_post
+run_test dump_kdump_post
 

--- a/dump-kdump_pre/runtest.sh
+++ b/dump-kdump_pre/runtest.sh
@@ -37,10 +37,8 @@ dump_kdump_pre()
         report_file /root/kdump-pre.log
         [ -f /root/kdump-pre.log ] && error_log "- Not found kdump-pre.log"
         validate_vmcore_exists
-        ready_to_exit
     fi
 }
 
-log_info "- Start"
-dump_kdump_pre
+run_test dump_kdump_pre
 

--- a/dump-lvm/runtest.sh
+++ b/dump-lvm/runtest.sh
@@ -30,7 +30,7 @@ dump_lvm()
         kdump_prepare
 
         findmnt -kcno SOURCE "$MP" | grep "/dev/mapper/"
-        [ $? -eq 0 ] || log_fatal_error "- $MP is not LVM."
+        [ $? -eq 0 ] || log_error "- $MP is not LVM."
 
         config_kdump_fs
         report_system_info
@@ -40,9 +40,7 @@ dump_lvm()
         rm -f "${C_REBOOT}"
 
         validate_vmcore_exists
-        ready_to_exit
     fi
 }
 
-log_info "- Start"
-dump_lvm
+run_test dump_lvm

--- a/dump-nfs-ipv6/runtest.sh
+++ b/dump-nfs-ipv6/runtest.sh
@@ -26,7 +26,7 @@
 nfs_v6_sysrq_test()
 {
     if [ -z "${SERVERS}" -o -z "${CLIENTS}" ]; then
-        log_fatal_error "No Server or Client hostname"
+        log_error "No Server or Client hostname"
     fi
 
     # port used for client/server sync
@@ -45,12 +45,11 @@ nfs_v6_sysrq_test()
 
             log_info "- Notifying server that test is done at client."
             send_notify_signal "${SERVERS}" ${done_sync_port}
-            log_fatal_error "- Failed to trigger crash."
+            log_error "- Failed to trigger crash."
 
         elif [[ $(get_role) == "server" ]]; then
             log_info "- Waiting for signal that test is done at client."
             wait_for_signal ${done_sync_port}
-            ready_to_exit
         fi
     else
         rm -f "${C_REBOOT}"
@@ -60,12 +59,10 @@ nfs_v6_sysrq_test()
         log_info "- Notifying server that test is done at client."
         send_notify_signal "${SERVERS}" ${done_sync_port}
 
-        [ ${retval} -eq 0 ] || log_fatal_error "- Failed to copy vmcore"
+        [ ${retval} -eq 0 ] || log_error "- Failed to copy vmcore"
 
         validate_vmcore_exists
-        ready_to_exit
     fi
 }
 
-log_info "- Start"
-nfs_v6_sysrq_test
+run_test nfs_v6_sysrq_test

--- a/dump-nfs-nomount/runtest.sh
+++ b/dump-nfs-nomount/runtest.sh
@@ -26,7 +26,7 @@
 nfs_sysrq_nomount()
 {
     if [ -z "${SERVERS}" -o -z "${CLIENTS}" ]; then
-        log_fatal_error "No Server or Client hostname"
+        log_error "No Server or Client hostname"
     fi
 
     # port used for client/server sync
@@ -60,12 +60,11 @@ nfs_sysrq_nomount()
 
             log_info "- Notifying server that test is done at client."
             send_notify_signal "${SERVERS}" ${done_sync_port}
-            log_fatal_error "- Failed to trigger crash."
+            log_error "- Failed to trigger crash."
 
         elif [[ $(get_role) == "server" ]]; then
             log_info "- Waiting for signal that test is done at client."
             wait_for_signal ${done_sync_port}
-            ready_to_exit
         fi
     else
         rm -f "${C_REBOOT}"
@@ -75,12 +74,10 @@ nfs_sysrq_nomount()
         log_info "- Notifying server that test is done at client."
         send_notify_signal "${SERVERS}" ${done_sync_port}
 
-        [ ${retval} -eq 0 ] || log_fatal_error "- Failed to copy vmcore"
+        [ ${retval} -eq 0 ] || log_error "- Failed to copy vmcore"
 
         validate_vmcore_exists
-        ready_to_exit
     fi
 }
 
-log_info "- Start"
-nfs_sysrq_nomount
+run_test nfs_sysrq_nomount

--- a/dump-nfs/runtest.sh
+++ b/dump-nfs/runtest.sh
@@ -26,7 +26,7 @@
 nfs_sysrq_test()
 {
     if [ -z "${SERVERS}" -o -z "${CLIENTS}" ]; then
-        log_fatal_error "No Server or Client hostname"
+        log_error "No Server or Client hostname"
     fi
 
     # port used for client/server sync
@@ -45,12 +45,11 @@ nfs_sysrq_test()
 
             log_info "- Notifying server that test is done at client."
             send_notify_signal "${SERVERS}" ${done_sync_port}
-            log_fatal_error "- Failed to trigger crash."
+            log_error "- Failed to trigger crash."
 
         elif [[ $(get_role) == "server" ]]; then
             log_info "- Waiting for signal that test is done at client."
             wait_for_signal ${done_sync_port}
-            ready_to_exit
         fi
     else
         rm -f "${C_REBOOT}"
@@ -60,12 +59,10 @@ nfs_sysrq_test()
         log_info "- Notifying server that test is done at client."
         send_notify_signal "${SERVERS}" ${done_sync_port}
 
-        [ ${retval} -eq 0 ] || log_fatal_error "- Failed to copy vmcore"
+        [ ${retval} -eq 0 ] || log_error "- Failed to copy vmcore"
 
         validate_vmcore_exists
-        ready_to_exit
     fi
 }
 
-log_info "- Start"
-nfs_sysrq_test
+run_test nfs_sysrq_test

--- a/dump-nr_cpus/runtest.sh
+++ b/dump-nr_cpus/runtest.sh
@@ -45,9 +45,7 @@ dump_nr_cpus()
     else
         rm -f "${C_REBOOT}"
         validate_vmcore_exists
-        ready_to_exit
     fi
 }
 
-log_info "- Start"
-dump_nr_cpus
+run_test dump_nr_cpus

--- a/dump-partition-DevName/runtest.sh
+++ b/dump-partition-DevName/runtest.sh
@@ -35,10 +35,8 @@ dump_partition_DevName()
         rm -f "${C_REBOOT}"
 
         validate_vmcore_exists
-        ready_to_exit
     fi
 
 }
 
-log_info "- Start"
-dump_partition_DevName
+run_test dump_partition_DevName

--- a/dump-partition-Label/runtest.sh
+++ b/dump-partition-Label/runtest.sh
@@ -38,10 +38,8 @@ dump_partition_Label()
     else
         rm -f "${C_REBOOT}"
         validate_vmcore_exists
-        ready_to_exit
     fi
 }
 
-log_info "- Start"
-dump_partition_Label
+run_test dump_partition_Label
 

--- a/dump-partition-UUID/runtest.sh
+++ b/dump-partition-UUID/runtest.sh
@@ -36,10 +36,8 @@ dump_partition_UUID()
     else
         rm -f "${C_REBOOT}"
         validate_vmcore_exists
-        ready_to_exit
     fi
 }
 
-log_info "- Start"
-dump_partition_UUID
+run_test dump_partition_UUID
 

--- a/dump-ssh-ipv6/runtest.sh
+++ b/dump-ssh-ipv6/runtest.sh
@@ -26,7 +26,7 @@
 ssh_v6_sysrq_test()
 {
     if [ -z "${SERVERS}" -o -z "${CLIENTS}" ]; then
-        log_fatal_error "No Server or Client hostname"
+        log_error "No Server or Client hostname"
     fi
 
     # port used for client/server sync
@@ -46,7 +46,7 @@ ssh_v6_sysrq_test()
 
             log_info "- Notifying server that test is done at client."
             send_notify_signal "${SERVERS}" ${done_sync_port}
-            log_fatal_error "- Failed to trigger crash."
+            log_error "- Failed to trigger crash."
 
         elif [[ $(get_role) == "server" ]]; then
             log_info "- Waiting at ${done_sync_port} for signal from client that test/crash is done."
@@ -54,15 +54,12 @@ ssh_v6_sysrq_test()
 
             log_info "- Checking vmcore on ssh server."
             validate_vmcore_exists flat
-            ready_to_exit
         fi
     else
         rm -f "${C_REBOOT}"
         log_info "- Notifying server that crash is done at client."
         send_notify_signal "${SERVERS}" ${done_sync_port}
-        ready_to_exit
     fi
 }
 
-log_info "- Start"
-ssh_v6_sysrq_test
+run_test ssh_v6_sysrq_test

--- a/dump-ssh/runtest.sh
+++ b/dump-ssh/runtest.sh
@@ -27,7 +27,7 @@
 ssh_sysrq_test()
 {
     if [ -z "${SERVERS}" -o -z "${CLIENTS}" ]; then
-        log_fatal_error "No Server or Client hostname"
+        log_error "No Server or Client hostname"
     fi
 
     # port used for client/server sync
@@ -47,7 +47,7 @@ ssh_sysrq_test()
 
             log_info "- Notifying server that test is done at client."
             send_notify_signal "${SERVERS}" ${done_sync_port}
-            log_fatal_error "- Failed to trigger crash."
+            log_error "- Failed to trigger crash."
 
         elif [[ $(get_role) == "server" ]]; then
             log_info "- Waiting at ${done_sync_port} for signal from client that test/crash is done."
@@ -55,15 +55,12 @@ ssh_sysrq_test()
 
             log_info "- Checking vmcore on ssh server."
             validate_vmcore_exists flat
-            ready_to_exit
         fi
     else
         rm -f "${C_REBOOT}"
         log_info "- Notifying server that crash is done at client."
         send_notify_signal "${SERVERS}" ${done_sync_port}
-        ready_to_exit
     fi
 }
 
-log_info "- Start"
-ssh_sysrq_test
+run_test ssh_sysrq_test

--- a/lib/crash.sh
+++ b/lib/crash.sh
@@ -60,7 +60,7 @@ get_vmcore_path()
     }
 
     [ ! -d "${vmcore_path}" ] && {
-        log_fatal_error "- Failed to find vmcore. ${vmcore_path} is not a directory"
+        log_error "- Failed to find vmcore. ${vmcore_path} is not a directory"
     }
 
     local find_cmd="find "\"${vmcore_path}\"" -newer "\"${K_CONFIG}\"" -name "\"${vmcore_name}\"" -type f"
@@ -68,7 +68,7 @@ get_vmcore_path()
 
     local vmcore_full_path
     if [[ ${count} -gt 1 ]]; then
-        log_fatal_error "- More than one vmcore is found in ${vmcore_path}. Expect 1 or 0."
+        log_error "- More than one vmcore is found in ${vmcore_path}. Expect 1 or 0."
     else
         vmcore_full_path=$(eval "${find_cmd}")
         echo "${vmcore_full_path}"
@@ -94,17 +94,17 @@ validate_vmcore_exists()
     if [ ! -z "${vmcore_full_path}" ]; then
         log_info "- Found vmcore ${vmcore_format} file at ${vmcore_full_path}"
     else
-        log_fatal_error "- No vmcore file is found."
+        log_error "- No vmcore file is found."
     fi
 
-    # if no vmcore format is specified, check vmcore-dmesg as well.
+    # if vmcore format is not specified, check vmcore-dmesg as well.
     [[ -z ${vmcore_format} ]] && {
         log_info "- Validate if vmcore-dmesg.txt exists"
         vmcore_full_path=$(get_vmcore_path "dmesg")
         if [ ! -z "${vmcore_full_path}" ]; then
             log_info "- Found vmcore-dmesg file at ${vmcore_full_path}"
         else
-            log_fatal_error "- No vmcore-dmesg is found."
+            log_error "- No vmcore-dmesg is found."
         fi
     }
 }
@@ -124,7 +124,7 @@ validate_vmcore_not_exists()
     vmcore_full_path=$(get_vmcore_path "${vmcore_format}")
 
     if [ ! -z "${vmcore_full_path}" ]; then
-        log_fatal_error "- Found vmcore file at ${vmcore_full_path}"
+        log_error "- Found vmcore file at ${vmcore_full_path}"
     else
         log_info "- No vmcore file is found."
     fi
@@ -151,7 +151,7 @@ crash_cmd()
 
     local retval
 
-    [ -f "${crash_cmd_file}" ] || log_fatal_error "- No such file ${crash_cmd_file}."
+    [ -f "${crash_cmd_file}" ] || log_error "- No such file ${crash_cmd_file}."
 
     log_info "- # crash ${args} -i ${crash_cmd_file} ${vmx} ${core}"
     # The EOF part is a workaround of a crash utility bug - crash utility
@@ -167,12 +167,12 @@ EOF
 
 
     # check return code of the crash command
-    [ $retval == 0 ] || log_fatal_error "- Crash returns error code ${retval}"
+    [ $retval == 0 ] || log_error "- Crash returns error code ${retval}"
 
     # check output of the crash command
     if [ -n "${func_check_output}" ]; then
         ${func_check_output} "${crash_cmd_file}.${log_suffix}"
-        [ $? == 0 ] || log_fatal_error "- Failed to run: \
+        [ $? == 0 ] || log_error "- Failed to run: \
             ${func_check_output} ${crash_cmd_file}.${log_suffix}"
     fi
     log_info "- Done running and checking crash cmd."
@@ -340,7 +340,7 @@ check_crash_output()
 
     if [[ ${error_found} -eq 0 || ${warn_found} -eq 0 ]]; then
         report_file "${K_CRASH_REPORT}"
-        log_fatal_error "- Found errors/warnings in Crash commands. \
+        log_error "- Found errors/warnings in Crash commands. \
             See ${output_file} for more details."
     fi
 
@@ -373,7 +373,7 @@ check_gdb_output()
                 -e 'error' \
                 -e 'invalid' \
        2>&1; then
-        log_fatal_error "- Found errors/warnings in GDB commands. \
+        log_error "- Found errors/warnings in GDB commands. \
             See ${output_file} for more details."
     else
         log_info "- Finished analysing GDB output.\

--- a/lib/kdump.sh
+++ b/lib/kdump.sh
@@ -93,7 +93,7 @@ install_rpm()
 {
     if [[ $# -gt 0 ]]; then
         for pkg in $@; do
-            rpm -q $pkg || yum install -y $pkg || log_fatal_error "- Install package $pkg failed!"
+            rpm -q $pkg || yum install -y $pkg || log_error "- Install package $pkg failed!"
         done
         log_info "- Installed $* successfully"
     fi
@@ -116,7 +116,7 @@ install_rpm_from_repo()
         local repo=$2
         local opt=${3:-"install"}
         $cmd ${opt} -y --enablerepo=$repo $pkg
-        [[ $? -ne 0  ]] && log_fatal_error "- Install/upgrade package $pkg from $repo failed!"
+        [[ $? -ne 0  ]] && log_error "- Install/upgrade package $pkg from $repo failed!"
         log_info "- Installed/upgraded $pkg from $repo successfully"
     fi
 }
@@ -129,7 +129,7 @@ install_rpm_from_repo()
 # @param3: dest  # path to dir where .ko will be generated to. defaul to <name>
 make_module()
 {
-    [ $# -lt 2 ] && log_fatal_error "- No module name or from path"
+    [ $# -lt 2 ] && log_error "- No module name or from path"
     local name=$1
     local from=$2
     local dest=${3:-$name}
@@ -139,7 +139,7 @@ make_module()
     cp "${from}"/Makefile."${name}" "${dest}/Makefile"
 
     unset ARCH
-    make -C "${name}/" || log_fatal_error "- Can not make module."
+    make -C "${name}/" || log_error "- Can not make module."
     export ARCH
     ARCH=$(uname -m)
 }
@@ -152,14 +152,14 @@ make_module()
 # @param3: dest  # path to dir where .ko will be generated to. defaul to <name>
 make_install_module()
 {
-    [ $# -lt 2 ] && log_fatal_error "- No module name or from path"
+    [ $# -lt 2 ] && log_error "- No module name or from path"
     local name=$1
     local from=$2
     local dest=${3:-$name}
 
     make_module "${name}" "${from}" "${dest}"
 
-    insmod "${dest}/${name}.ko" || log_fatal_error "- Failed to insmod module."
+    insmod "${dest}/${name}.ko" || log_error "- Failed to insmod module."
 }
 
 
@@ -169,7 +169,7 @@ make_install_module()
 # @description: install required packakges for multi-host tests
 multihost_prepare()
 {
-    which nc || yum install -y nmap-ncat || yum install -y nc || log_fatal_error "- Failed to install nc client"
+    which nc || yum install -y nmap-ncat || yum install -y nc || log_error "- Failed to install nc client"
 }
 
 
@@ -255,7 +255,7 @@ kdump_prepare()
                     --update-kernel="${default}" &&
                 if [ "${K_ARCH}" = "s390x" ]; then zipl; fi
             } || {
-                log_fatal_error "- Change boot loader error!"
+                log_error "- Change boot loader error!"
             }
             log_info "- Reboot system for system preparing."
             reboot_system
@@ -266,7 +266,7 @@ kdump_prepare()
     # if not, print out cmdline and exit.
     if [ "$(cat /sys/kernel/kexec_crash_size)" -eq 0 ]; then
         log_info "- Kernel Boot Cmdline is: $(cat /proc/cmdline)"
-        log_fatal_error "- No memory is reserved for crashkernel!"
+        log_error "- No memory is reserved for crashkernel!"
     fi
 
     # enable sysrq
@@ -274,7 +274,7 @@ kdump_prepare()
     sysctl -p
 
     # enable kdump service: systemd
-    /bin/systemctl enable kdump.service || /sbin/chkconfig kdump on || log_fatal_error "- Failed to enable kdump!"
+    /bin/systemctl enable kdump.service || /sbin/chkconfig kdump on || log_error "- Failed to enable kdump!"
     log_info "- Enabled kdump service."
     kdump_restart
 }
@@ -319,7 +319,7 @@ kdump_restart()
     rm -f /boot/initramfs-*kdump.img  # for rhel7
     touch "${K_CONFIG}"
 
-    /usr/bin/kdumpctl restart 2>&1 || /sbin/service kdump restart 2>&1 || log_fatal_error "- Failed to start kdump!"
+    /usr/bin/kdumpctl restart 2>&1 || /sbin/service kdump restart 2>&1 || log_error "- Failed to start kdump!"
     log_info "- Kdump service starts successfully."
 }
 
@@ -375,7 +375,7 @@ remove_config()
 #   config_kdump_any "kdump_post /bin/your_script"
 config_kdump_any()
 {
-    [ $# -eq 0 ] && log_fatal_error "- Expect a config line"
+    [ $# -eq 0 ] && log_error "- Expect a config line"
     append_config "$1"
     kdump_restart
 }
@@ -413,7 +413,7 @@ label_fs()
             ;;
     esac
 
-    [ $? -ne 0 ] && log_fatal_error "- Failed to label $fstype with $label on $dev"
+    [ $? -ne 0 ] && log_error "- Failed to label $fstype with $label on $dev"
 }
 
 
@@ -448,7 +448,7 @@ config_kdump_fs()
     fi
 
     if [[ -n "$required_fstype" &&  "$required_fstype" != "$fstype" ]]; then
-        log_fatal_error "- Expect ${MP} to be fs_type ${required_fstype}, but it's ${fstype}"
+        log_error "- Expect ${MP} to be fs_type ${required_fstype}, but it's ${fstype}"
     fi
 
     # get target
@@ -484,7 +484,7 @@ config_kdump_fs()
         # tell crash analyse procedure where to find vmcore
         echo "${MP%/}${KPATH}" > "${K_PATH}"
     else
-        log_fatal_error "- Null dump_device/uuid/label or wrong type."
+        log_error "- Null dump_device/uuid/label or wrong type."
     fi
 
     kdump_restart
@@ -525,7 +525,7 @@ config_kdump_sysconfig()
 {
     log_info "- Updating kdump sysconfig."
 
-    [ $# -lt 3 ] && log_fatal_error "- Expect at least 3 args."
+    [ $# -lt 3 ] && log_error "- Expect at least 3 args."
     local key=$1
     local action=$2
     local value1=$3
@@ -544,14 +544,14 @@ config_kdump_sysconfig()
             sed -i  /^"$key="/s/"$value1"//g "${K_SYS_CONFIG}"
             ;;
         replace)
-            [ -z "$value2" ] && log_fatal_error "- Missing new_value for replacing."
+            [ -z "$value2" ] && log_error "- Missing new_value for replacing."
             sed -i  /^"$key="/s/"$value1"/"$value2"/g "${K_SYS_CONFIG}"
             ;;
         *)
-            log_fatal_error "- Invalid action '${action}' for editing kdump sysconfig."
+            log_error "- Invalid action '${action}' for editing kdump sysconfig."
             ;;
     esac
-    [ $? -ne 0 ] && log_fatal_error "- Failed to updated kdump sysconfig."
+    [ $? -ne 0 ] && log_error "- Failed to updated kdump sysconfig."
     sync;sync;sync
     # it requires to reload the crash kernel for kdump
     kdump_restart
@@ -570,7 +570,7 @@ trigger_sysrq_crash()
     echo c > /proc/sysrq-trigger
 
     sleep 60
-    log_fatal_error "- Failed to trigger crash after waiting for 60s."
+    log_error "- Failed to trigger crash after waiting for 60s."
 }
 
 
@@ -581,7 +581,7 @@ trigger_sysrq_crash()
 # @parma1: opt
 trigger_crasher()
 {
-    [ $# -lt 1 ] && log_fatal_error "- Missing opt to trigger crasher"
+    [ $# -lt 1 ] && log_error "- Missing opt to trigger crasher"
 
     local opt=$1
     touch "${C_REBOOT}"
@@ -597,7 +597,23 @@ trigger_crasher()
     echo $opt > /proc/crasher
 
     sleep 60
-    log_fatal_error "- Failed to trigger crash after waiting for 60s."
+    log_error "- Failed to trigger crash after waiting for 60s."
 }
 
+# @usage: trigger_crasher <test_name>
+# @description:
+#       run <test_name> and exit
+# @parma1: test_name
+run_test()
+{
+    func=$1
 
+    warn=0
+    error=0
+
+    log_info "- Start"
+
+    ${func}
+
+    ready_to_exit
+}

--- a/lib/kdump_multi.sh
+++ b/lib/kdump_multi.sh
@@ -39,7 +39,7 @@ get_role()
         echo "client"; return
     fi
 
-    log_fatal_error "- Unable to determine host role."
+    log_error "- Unable to determine host role."
 }
 
 
@@ -63,7 +63,7 @@ is_host_ip()
 # @param1: fw_service
 open_firewall_service()
 {
-    [ $# -lt 1 ] && log_fatal_error "- Syntax error: Expecting a service name."
+    [ $# -lt 1 ] && log_error "- Syntax error: Expecting a service name."
 
     local fw_service=$1
 
@@ -90,7 +90,7 @@ open_firewall_service()
 # @param2: fw_port
 open_firewall_port()
 {
-    [ $# -lt 2 ] && log_fatal_error "- Syntax error: Expecting a protocol and port"
+    [ $# -lt 2 ] && log_error "- Syntax error: Expecting a protocol and port"
 
     local fw_protocol=$1
     local fw_port=$2
@@ -137,7 +137,7 @@ wait_for_signal()
     if [ $? == 0 ]; then
         log_info "- Received signal at port $1"
     else
-        log_fatal_error "- Failed to listen for signal at port $1"
+        log_error "- Failed to listen for signal at port $1"
     fi
 }
 
@@ -169,7 +169,7 @@ send_notify_signal()
     done
 
     if [ "${retval}" -eq 1 ]; then
-        log_fatal_error "- Failed to notify server, got timeout."
+        log_error "- Failed to notify server, got timeout."
     else
         log_info "- Sent notify signal to ${server} at ${port} successfully"
     fi
@@ -199,7 +199,7 @@ config_ssh()
 
     local ip_version=${1:-"v4"}
     [[  "${ip_version}" =~ ^(v4|v6)$ ]] || {
-        log_fatal_error "- ${ip_version} is not supported. Onlyl ipv4 or ipv6 is supported."
+        log_error "- ${ip_version} is not supported. Onlyl ipv4 or ipv6 is supported."
     }
 
     if [[ $(get_role) == "client" ]]; then  # copy keys
@@ -215,7 +215,7 @@ config_ssh()
         if [[ ${ip_version} == "v6" ]]; then
             # get server ipv6 address
             ssh -i "${K_LOCK_SSH_ID_RSA}" "${server}" "cat ${path_ipv6_addr}" > ${path_ipv6_addr}.out
-            [ $? -eq 0 ] || log_fatal_error "- Failed to get server ipv6 address."
+            [ $? -eq 0 ] || log_error "- Failed to get server ipv6 address."
             server_ipv6=$(grep -P '^[0-9]+' "${path_ipv6_addr}".out | head -1)
             append_config "ssh root@${server_ipv6}"
         else
@@ -244,7 +244,7 @@ config_ssh()
         wait_for_signal ${sync_port}
 
     else
-        log_fatal_error "- Can not determine the role of host."
+        log_error "- Can not determine the role of host."
     fi
 }
 
@@ -289,7 +289,7 @@ config_nfs()
         else
             [[ "${TESTARGS:=nfs}" == nfs ]]
         fi
-        [ $? == 0 ] || log_fatal_error "The nfs opt passed in TESTARGS is invalid."
+        [ $? == 0 ] || log_error "The nfs opt passed in TESTARGS is invalid."
 
         local server_addr=${SERVERS}
         [ "${ip_version}" == "v6" ] && {
@@ -299,7 +299,7 @@ config_nfs()
             [ $? == 0 ] || {
                 log_info "- Notifying server that kdump config is done at client."
                 send_notify_signal "${server}" "${sync_port}"
-                log_fatal_error "- Failed to get server ipv6 address."
+                log_error "- Failed to get server ipv6 address."
             }
             server_addr=[$(grep -P '^[0-9]+' "${path_ipv6_addr}".out | head -1)]
         }
@@ -345,13 +345,13 @@ config_nfs()
         if [ ${retval} -eq 0 ]; then
             log_info "- NFS server is started"
         else
-            log_fatal_error "- Failed to start NFS server."
+            log_error "- Failed to start NFS server."
         fi
 
         log_info "- Waiting signal that kdump config is done at client"
         wait_for_signal ${sync_port}
     else
-        log_fatal_error "- Can not determine the role of host."
+        log_error "- Can not determine the role of host."
     fi
 }
 
@@ -415,7 +415,7 @@ prepare_ssh_connection()
         [ $? == 0 ] || {
             log_info "- Notifying server that ssh connection failed at client"
             send_notify_signal "${server}" "${sync_port}" ## MUST DO
-            log_fatal_error "- SSH connection test failed."
+            log_error "- SSH connection test failed."
         }
 
         log_info "- SSH connection test passed."
@@ -446,10 +446,10 @@ prepare_ssh_connection()
         log_info "- Notifying client that ssh preparation is done at server"
         send_notify_signal "${client}" "${sync_port}"
 
-        [ "${retval}" == 0 ] || log_fatal_error "- Failed to get ipv6 address from Server"
+        [ "${retval}" == 0 ] || log_error "- Failed to get ipv6 address from Server"
 
     else
-        log_fatal_error "- Unknown role: ${role}"
+        log_error "- Unknown role: ${role}"
     fi
 }
 

--- a/makedumpfile-merge-split/runtest.sh
+++ b/makedumpfile-merge-split/runtest.sh
@@ -75,11 +75,11 @@ makedumpfile_merge_split()
     # in case kernel is updated after crash_prepare()
     VMLINUX="/usr/lib/debug/lib/modules/$(uname -r)/vmlinux"
 
-    [ ! -f "${VMLINUX}" ] && log_fatal_error "- Unable to find vmlinux."
+    [ ! -f "${VMLINUX}" ] && log_error "- Unable to find vmlinux."
 
     local core
     core=$(get_vmcore_path)
-    [ -z "${core}" ] && log_fatal_error "- Unable to find vmcore."
+    [ -z "${core}" ] && log_error "- Unable to find vmcore."
 
     local split_cmd
     local merge_cmd
@@ -91,19 +91,14 @@ makedumpfile_merge_split()
 
     log_info "- # ${split_cmd}"
     eval "${split_cmd} 2>&1"
-    retval=$?
-    [ "${retval}" -ne 0 ] && log_fatal_error "- The makedumpfile command returns ${retval}"
+    [ "$?" -ne 0 ] && log_error "- The makedumpfile command returns ${retval}"
 
     log_info "- # ${merge_cmd}"
     eval "${merge_cmd} 2>&1"
-    retval=$?
-    [ "${retval}" -ne 0 ] && log_fatal_error "- The makedumpfile command returns ${retval}"
+    [ "$?" -ne 0 ] && log_error "- The makedumpfile command returns ${retval}"
 
     log_info "- Validating the merged dumpfile."
     verify_scrub
-
-    ready_to_exit
 }
 
-log_info "- Start"
-makedumpfile_merge_split
+run_test makedumpfile_merge_split

--- a/summary-test-result/runtest.sh
+++ b/summary-test-result/runtest.sh
@@ -30,17 +30,17 @@ summary_test_result()
         local warn
 
         total=$(wc -l < "${K_TEST_SUMMARY}")
-        pass=$(grep -o 'Pass' "${K_TEST_SUMMARY}" | wc -l)
-        fail=$(grep -o 'Fail' "${K_TEST_SUMMARY}" | wc -l)
-        warn=$(grep -o 'Warn' "${K_TEST_SUMMARY}" | wc -l)
+        pass=$(grep -o 'PASS' "${K_TEST_SUMMARY}" | wc -l)
+        fail=$(grep -o 'FAIL' "${K_TEST_SUMMARY}" | wc -l)
+        warn=$(grep -o 'WARN' "${K_TEST_SUMMARY}" | wc -l)
 
-        sed -i '1i\+-------- Test Result -------+' "${K_TEST_SUMMARY}"
-        echo "+--------- Summary ----------+" >> "${K_TEST_SUMMARY}"
+        sed -i '1i\+------------ Test Result -----------+' "${K_TEST_SUMMARY}"
+        echo "+------------- Summary --------------+" >> "${K_TEST_SUMMARY}"
         echo -e "Total:\t${total}" >> "${K_TEST_SUMMARY}"
         echo -e "Passed:\t${pass}" >> "${K_TEST_SUMMARY}"
         echo -e "Warned:\t${warn}" >> "${K_TEST_SUMMARY}"
         echo -e "Failed:\t${fail}" >> "${K_TEST_SUMMARY}"
-        echo "+-----------------------------+" >> "${K_TEST_SUMMARY}"
+        echo "+-------------------------------------+" >> "${K_TEST_SUMMARY}"
         report_file "${K_TEST_SUMMARY}"
 }
 


### PR DESCRIPTION
Updated test logging
- log_warn() - log warn message and add warn count.
- log_error() - log error message and exit current test as FAIL.
- log_fatal() - log error message and exit current test as FAIL. All other tests will be aborted
- Current errors in all test cases are updated to non-fatal errors.

Wrapped calling of each test in run_test()
- No need to log "- Start" explicitly
- No need to call ready_to_exit() for each test explicitly

Updated test exiting
- run_test() calls ready_to_exit() at the end of each test
- If error/fatal error occurs, ready_to_exit() will be called immediately.

Signed-off-by: xiawu <xiawu@redhat.com>