### PR TITLE
Update next boot option in case efi

### DIFF
--- a/crash-altsysrq-c/runtest.sh
+++ b/crash-altsysrq-c/runtest.sh
@@ -30,6 +30,8 @@ crash_altsysrq_c()
         make_module "altsysrq" .
         insmod ./altsysrq/altsysrq.ko || log_error "- Fail to insmod altsysrq."
 
+        reset_efiboot
+
         touch "${C_REBOOT}"
         sync
         log_info "- Triggering crash."

--- a/crash-nmi-switch/runtest.sh
+++ b/crash-nmi-switch/runtest.sh
@@ -33,6 +33,8 @@ crash_nmi_switch()
         systemctl enable ipmi
         systemctl start ipmi || service ipmi start || log_error "- Failed to start ipmi service."
 
+        reset_efiboot
+
         echo 1 > /proc/sys/kernel/panic_on_unrecovered_nmi
         touch "${C_REBOOT}"
         sync

--- a/crash-oops-warn/runtest.sh
+++ b/crash-oops-warn/runtest.sh
@@ -32,6 +32,8 @@ crash-oops-warn()
         echo 1 > /proc/sys/kernel/panic_on_warn
         [[ $? -ne 0 ]] && log_error "- Error to echo 1 > /proc/sys/kernel/panic_on_warn"
 
+        reset_efiboot
+
         # Trigger panic_on_warn
         touch "${C_REBOOT}"
         sync

--- a/lib/kdump.sh
+++ b/lib/kdump.sh
@@ -560,6 +560,9 @@ trigger_sysrq_crash()
 {
     touch "${C_REBOOT}"
     sync;sync;sync
+
+    reset_efiboot
+
     log_info "- Triggering crash."
     echo c > /proc/sysrq-trigger
 
@@ -579,9 +582,14 @@ trigger_crasher()
 
     local opt=$1
     touch "${C_REBOOT}"
+
+    reset_efiboot
+
     # enable panic_on_oops
     echo 1 > /proc/sys/kernel/panic_on_oops
     sync;sync;sync
+
+
 
     log_info "- Triggering crash."
     # opt=0 : panic()

--- a/lib/log.sh
+++ b/lib/log.sh
@@ -209,8 +209,25 @@ reboot_system()
     sync
 
     if is_beaker_env; then
+        # Config next boot if uefi
+        reset_efiboot
+
         rhts-reboot
     else
         reboot
     fi
+}
+
+# @usage: reset_efiboot
+# @description: set efi next boot option as current
+reset_efiboot()
+{
+    which efibootmgr && {
+        local boot_current
+        boot_current=$(efibootmgr | grep -i BootCurrent | awk  '{print $2}')
+        log_info "- Updating NextBoot in efibootmgr to ${boot_current}"
+        efibootmgr -n ${boot_current} || {
+            log_error "- Command 'efibootmgr -n ${boot_current}' failed!"
+        }
+    }
 }


### PR DESCRIPTION
Reset next boot option as current if EFI boot in beaker.
The reset will be called before each system reboot and before triggering system panic.

Signed-off-by: xiawu <xiawu@redhat.com>