### PR TITLE
crash_nmi_switch: Enabled unknown_nmi_panic and kernel panic in sysctl

### DIFF
--- a/crash-nmi-switch/runtest.sh
+++ b/crash-nmi-switch/runtest.sh
@@ -36,10 +36,13 @@ crash_nmi_switch()
         reset_efiboot
 
         echo 1 > /proc/sys/kernel/panic_on_unrecovered_nmi
+        echo 1 > /proc/sys/kernel/unknown_nmi_panic
+        echo 1 > /proc/sys/kernel/panic
+
         touch "${C_REBOOT}"
         sync
         log_info "- Triggering crash."
-        ipmitool chassis power diag
+        ipmitool power diag
 
         # Wait for a while
         sleep 60


### PR DESCRIPTION
Changed ipmitool cmd as well to trigger panic

Signed-off-by: xiawu <xiawu@redhat.com>