### PR TITLE
lib/kdump: Sync and wait after restarting kdump service

### DIFF
--- a/lib/kdump.sh
+++ b/lib/kdump.sh
@@ -318,6 +318,8 @@ kdump_restart()
 
     /usr/bin/kdumpctl restart 2>&1 || /sbin/service kdump restart 2>&1 || log_error "- Failed to start kdump!"
     log_info "- Kdump service starts successfully."
+
+    sync; sync; sleep 10
 }
 
 


### PR DESCRIPTION
To be more sure that kdump initramf img is written to disk.

Signed-off-by: xiawu <xiawu@redhat.com>