### PR TITLE
dump-nfs: save nfs dump path

### DIFF
--- a/lib/crash.sh
+++ b/lib/crash.sh
@@ -85,6 +85,7 @@ validate_vmcore_exists()
     vmcore_full_path=$(get_vmcore_path "${vmcore_format}")
 
     [ -z "${vmcore_full_path}" ] && log_error "- No vmcore file is found."
+    log_info "- Found vmcore file at ${vmcore_full_path}"
 
     # if vmcore format is not specified, check vmcore-dmesg as well.
     [[ -z ${vmcore_format} ]] && {

--- a/lib/kdump_multi.sh
+++ b/lib/kdump_multi.sh
@@ -280,6 +280,9 @@ config_nfs()
 
     open_firewall_port tcp "${sync_port}"
 
+    echo "/${client}" > "${K_PATH}"
+    echo "${K_EXPORT}" > "${K_NFS}"
+
     if [[ $(get_role) == "client" ]]; then  # copy keys
         ## Note:
         ## If client exits with error during config. server must be notified.
@@ -307,12 +310,10 @@ config_nfs()
         }
 
         append_config "${TESTARGS} ${server_addr}:${K_EXPORT}"
-        echo "${K_EXPORT}" > "${K_NFS}"
 
         # Config 'path' to client hostname
         # So client can fetch vmcore belong to itself.
         append_config "path /${client}"
-        echo "/${client}" > "${K_PATH}"
 
         # required only for RHEL6 or earlier
         [ "${K_DIST_VER}" == "6" ] && append_config "link_delay 60"
@@ -382,6 +383,7 @@ copy_nfs()
     cp -r "/mnt/tmp${vmcore_path}/"* "${export_path}${vmcore_path}" || return 1
 
     umount "/mnt/tmp"
+    rmdir "/mnt/tmp"
 }
 
 


### PR DESCRIPTION
so analyse-crash can be run on both server and client.

Signed-off-by: xiawu <xiawu@redhat.com>