### PR TITLE
lib/kdump: do not restart kdump again after rebooting

### DIFF
--- a/lib/kdump.sh
+++ b/lib/kdump.sh
@@ -296,7 +296,9 @@ kdump_prepare()
     # enable kdump service: systemd
     /bin/systemctl enable kdump.service || /sbin/chkconfig kdump on || log_error "- Failed to enable kdump!"
     log_info "- Enabled kdump service."
-    kdump_restart
+
+    # make sure kdumpctl is operational
+    kdumpctl status 2>&1 || service kdump status 2>&1 || log_error "- Kdump is not running!"
 }
 
 


### PR DESCRIPTION
This is to test if starting of kdump is handled correctly after rebooting.

Signed-off-by: xiawu <xiawu@redhat.com>