### PR TITLE
lib/kdump_multi.sh: Add more support for getting IPv6 address

### DIFF
--- a/lib/kdump_multi.sh
+++ b/lib/kdump_multi.sh
@@ -462,7 +462,7 @@ prepare_ssh_connection()
         # save ipv6 address to ${path_ipv6_addr}
         local retval=0
         [ "$ip_version" == "v6" ] && {
-            ifconfig | grep inet6\ | grep global | awk -F' ' '{print $2}' > ${path_ipv6_addr}
+            ifconfig | grep inet6\ | grep -i global | sed 's/addr://g' | sed -e 's/\/[[:digit:]]\+//g' | awk -F' ' '{print $2}' > ${path_ipv6_addr}
             retval=$?
         }
 


### PR DESCRIPTION
The way of getting IPv6 address now only works with such format of
ifconfig
  inet6 2:5:0:f:5250:00ff:fe00:0035  prefixlen 64  scopeid 0x0<global>
While in older ifconfig, the line looks like
  inet6 addr: 2:5:0:f:5250:00ff:fe00:0035/64 Scope:Global
With this patch, the script can get IPv6 address in both of the format.

Signed-off-by: Ziqian SUN (Zamir) <zsun@redhat.com>